### PR TITLE
set workflow token permissions

### DIFF
--- a/.github/workflows/repositories.yml
+++ b/.github/workflows/repositories.yml
@@ -24,7 +24,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       github.event_name == 'repository_dispatch'
     permissions:
-      contents: 'read'
+      contents: 'write' # needed for release upload
       id-token: 'write'
     steps:
       - name: Checkout

--- a/.github/workflows/repositories.yml
+++ b/.github/workflows/repositories.yml
@@ -23,6 +23,9 @@ jobs:
     if: github.event_name == 'release' ||
       github.event_name == 'workflow_dispatch' ||
       github.event_name == 'repository_dispatch'
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     steps:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7


### PR DESCRIPTION
[Run where it got passed the Google Auth](https://github.com/sourcegraph/amp-packages/actions/runs/16656665404/job/47143284971)
<img width="331" height="169" alt="Screenshot 2025-07-31 at 20 48 33" src="https://github.com/user-attachments/assets/6e064f34-d460-4111-96c4-17d4e28e59a7" />

I think the current failure is due to the terraform that creates the bucket + permissions [didn't complete ](https://app.terraform.io/app/sourcegraph/workspaces/msp-amp-prod-cloudrun/runs/run-zCL79vc1NSLA9wZu)so the WI Service account technically doesn't have access to the bucket _yet_

I verified that the service account can access other buckets ... so once the terraform completes (as per this [thread](https://sourcegraph.slack.com/archives/C05GJPTSZCZ/p1753987462248679)) ... it should just work (TM)
```
gcloud --impersonate-service-account=wi-gh-msp-amp-publishing@sourcegraph-dev.iam.gserviceaccount.com storage ls gs://static.ampcode.com
WARNING: This command is using service account impersonation. All API calls will be executed as [wi-gh-msp-amp-publishing@sourcegraph-dev.iam.gserviceaccount.com].
WARNING: This command is using service account impersonation. All API calls will be executed as [wi-gh-msp-amp-publishing@sourcegraph-dev.iam.gserviceaccount.com].
gs://static.ampcode.com/home/
gs://static.ampcode.com/news/
gs://static.ampcode.com/podcast/
```
